### PR TITLE
[CHG] Added exception handling when API failed to respond.

### DIFF
--- a/indeed-ruby.gemspec
+++ b/indeed-ruby.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'indeed-ruby'
-  s.version = '0.0.1'
+  s.version = '0.0.2'
   s.author = 'Indeed Labs'
   s.email = 'labs-team@indeed.com'
 

--- a/lib/indeed-ruby.rb
+++ b/lib/indeed-ruby.rb
@@ -25,9 +25,10 @@ module Indeed
             :required_fields => [:jobkeys],
         }
 
-        def initialize(publisher, version = "2")
+        def initialize(publisher, version = "2", timeout = 10)
             @publisher = publisher
             @version = version
+            @timeout = timeout
         end
 
         def search(params)
@@ -58,7 +59,7 @@ module Indeed
             raw = format == 'xml' ? true : args.fetch(:raw, false)
             args.merge!({:v => @version, :publisher => @publisher, :format => format})
             begin
-                Timeout.timeout(5) do
+                Timeout.timeout(@timeout) do
                     response = RestClient.get endpoint, {:params => args}
                     r = (not raw) ? JSON.parse(response.to_str) : response.to_str
                     r


### PR DESCRIPTION
**IMPORTANT**
This gem is currently using depreciated version of the INDEED API.

**PROBLEM STATEMENT**
We have identified an issue where the gem does not handle exceptions effectively when incorrect parameters are passed or when the API endpoint is unavailable or returns an empty response. As a result, the client needs to manually parse the error messages received from the gem.

**SOLUTION**
To address this issue, we have implemented improved exception handling within the gem to return more informative error messages. Additionally, we have incorporated a timeout mechanism that throws a timeout error if the API response exceeds 10 seconds. This timeout limit is configurable by the client as needed.
